### PR TITLE
Added showCaller and stringifyObjects

### DIFF
--- a/src/app/models/config.ts
+++ b/src/app/models/config.ts
@@ -8,7 +8,7 @@ export default class PixiConsoleConfig {
     fontErrorColor: number = 0xff0000;
     fontWarningColor: number = 0xf0e68c;
     stringifyObjects: boolean = false;
-    sourceMap: boolean = false;
+    showCaller: boolean = false;
 
     // events options
     eventsConfig: EventsConfig = new EventsConfig();

--- a/src/app/models/config.ts
+++ b/src/app/models/config.ts
@@ -7,6 +7,8 @@ export default class PixiConsoleConfig {
     fontColor: number = 0xffffff;
     fontErrorColor: number = 0xff0000;
     fontWarningColor: number = 0xf0e68c;
+    stringifyObjects: boolean = false;
+    sourceMap: boolean = false;
 
     // events options
     eventsConfig: EventsConfig = new EventsConfig();

--- a/src/app/pixi-console.ts
+++ b/src/app/pixi-console.ts
@@ -260,21 +260,51 @@ export default class PixiConsole extends PIXI.Container {
         }
     }
 
-    private _log(...messages: string[]): void {
+    private _log(...messages: any[]): void {
         messages.forEach((message) => {
-            this.print(message, this._config.fontColor, this._config.fontSize);
+            const finalMesage: string = this.messageBuilder(message);
+            this.print(finalMesage, this._config.fontColor, this._config.fontSize);
         });
     }
 
-    private _warn(...messages: string[]): void {
+    private _warn(...messages: any[]): void {
         messages.forEach((message) => {
-            this.print(message, this._config.fontWarningColor, this._config.fontSize);
+            const finalMesage: string = this.messageBuilder(message);
+            this.print(finalMesage, this._config.fontWarningColor, this._config.fontSize);
         });
     }
 
-    private _error(...messages: string[]): void {
+    private _error(...messages: any[]): void {
         messages.forEach((message) => {
-            this.print(message, this._config.fontErrorColor, this._config.fontSize);
+            const finalMesage: string = this.messageBuilder(message);
+            this.print(finalMesage, this._config.fontErrorColor, this._config.fontSize);
         });
+    }
+
+    private messageBuilder(message: any): string {
+        let finalMesage: string = "";
+
+        if (this._config.sourceMap) {
+            finalMesage += "(" + this.lineGuesser() + ")";
+        }
+
+        if (this._config.stringifyObjects && typeof message != "string") {
+            finalMesage += message.constructor.name + " ► " + JSON.stringify(message);
+        } else {
+            finalMesage += message;
+        }
+        return finalMesage;
+    }
+
+    private lineGuesser(): string {
+        // stolen from some god forsaken place in https://what.thedailywtf.com/topic/17379/make-console-log-log-current-line/2
+        const err = new Error();
+        if (err.stack) {
+            const caller_line = err.stack.split("\n")[5]; //5 here is because: 1 is lineGuesser, 2 is messageBuilder,3 is foreach, 4 is _log and 5 is the actual line that tried to log.
+            const index = caller_line.indexOf("at ");
+            const clean = caller_line.slice(index + 2, caller_line.length);
+            return clean;
+        }
+        return "";
     }
 }

--- a/src/app/pixi-console.ts
+++ b/src/app/pixi-console.ts
@@ -311,7 +311,7 @@ export default class PixiConsole extends PIXI.Container {
         // stolen from some god forsaken place in https://what.thedailywtf.com/topic/17379/make-console-log-log-current-line/2
         const err = new Error();
         if (err.stack) {
-            const caller_line = err.stack.split("\n")[7]; //reasoning this was 5 in my head, but 6 is the number that works
+            const caller_line = err.stack.split("\n")[7];
             const index = caller_line.indexOf("at ");
             const clean = caller_line.slice(index + 2, caller_line.length);
             return clean;

--- a/src/app/utils/one-depth.ts
+++ b/src/app/utils/one-depth.ts
@@ -1,0 +1,13 @@
+//This function limits a Json.Stringify to only one depth to prevent circular objects from exploding.
+export default function oneDepth(k: string, v: any): any {
+    if (!k || !v) return v;
+    if (typeof v == "object") {
+        if (v.constructor) {
+            return "[object " + v.constructor.name + "]";
+        } else {
+            return v;
+        }
+    } else {
+        return v;
+    }
+}


### PR DESCRIPTION
This PR adds two and a half feature:

This features are off by default and can be turned on in the `PixiConsoleConfig`.

1. `showCaller` makes it so that before the output you get the function and line that requested the log.
2. `stringifyObjects` uses `JSON.stringify` to display the inside of the objects instead of showing `[object Object]`
2.5. Even with `stringifyObjects` set to `false`, instead of showing `[object Object]` it tries to show the name of the class via `constructor.name`

Footnotes:
* If objects are circular (and most pixi objects are), JSON.stringify would crash so it engages a "safe mode" that only serializes the first depth of objects.
* default values for this two new flags in the settings are `false` to preserve the default behaviour of the lib.